### PR TITLE
Fix/disable legacy notifications

### DIFF
--- a/src/hooks/notifications/useNotificationManager.ts
+++ b/src/hooks/notifications/useNotificationManager.ts
@@ -60,11 +60,17 @@ export const useNotificationManager = () => {
       console.log('Adding valid notification:', newNotification);
       setNotifications(prev => [newNotification, ...prev]);
       
-      toast({
-        title: newNotification.title,
-        description: newNotification.message,
-        variant: "default",
-      });
+      if (
+        ENABLE_LEGACY_NOTIFICATION_RENDERING ||
+        (type !== 'participation-request')  // allow other toasts through
+      ) {
+        toast({
+          title: newNotification.title,
+          description: newNotification.message,
+          variant: "default",
+        });
+      }
+      
       
       if (areNotificationsEnabled()) {
         new window.Notification(newNotification.title, {

--- a/src/hooks/notifications/useNotificationManager.ts
+++ b/src/hooks/notifications/useNotificationManager.ts
@@ -6,6 +6,8 @@ import { useNotificationPermissions } from './useNotificationPermissions';
 import { parseISO, isToday, set } from 'date-fns';
 import { useLocation } from 'react-router-dom';
 
+const ENABLE_LEGACY_NOTIFICATION_RENDERING = false;
+
 export const useNotificationManager = () => {
   const { toast } = useToast();
   const { notificationsEnabled } = useNotificationPermissions();
@@ -72,7 +74,7 @@ export const useNotificationManager = () => {
       }
       
       // Only show modals if we're on the dashboard
-      if (isDashboard) {
+      if (isDashboard && ENABLE_LEGACY_NOTIFICATION_RENDERING) {
         if (type === 'participation-request') {
           console.log('Setting participation modal to show');
           setCurrentChallengeId(challengeId || null);

--- a/src/hooks/useNotificationSystem.ts
+++ b/src/hooks/useNotificationSystem.ts
@@ -16,6 +16,8 @@ import {
   shouldShowCompletionBox as checkShouldShowCompletionBox
 } from './notifications/dateUtils';
 
+const ENABLE_LEGACY_NOTIFICATIONS = false;
+
 export const useNotificationSystem = () => {
   console.log("useNotificationSystem hook initializing");
   const { user, profile, refreshProfile } = useAuth();
@@ -81,6 +83,9 @@ export const useNotificationSystem = () => {
   );
   
   const shouldShowParticipationBox = useMemo(() => {
+
+    if (!ENABLE_LEGACY_NOTIFICATIONS) return false; // Skip if legacy notifications are disabled
+
     if (forceHideParticipationBox) {
       console.log("Forcing hide participation box due to user response");
       return false;
@@ -114,6 +119,9 @@ export const useNotificationSystem = () => {
   }, [currentChallenge, notifications, forceHideParticipationBox]);
 
   const shouldShowCompletionBox = useMemo(() => {
+
+    if (!ENABLE_LEGACY_NOTIFICATIONS) return false; // Skip if legacy notifications are disabled
+
     const activeChallenge = currentChallenge || getCurrentChallengeId();
     console.log("Checking if completion box should show for challenge:", activeChallenge);
     return checkShouldShowCompletionBox(activeChallenge, notifications);
@@ -121,6 +129,9 @@ export const useNotificationSystem = () => {
   
   // Check for initial participation notification
   useEffect(() => {
+
+    if (!ENABLE_LEGACY_NOTIFICATIONS) return; // Skip if legacy notifications are disabled
+
     const challengeId = currentChallenge || getCurrentChallengeId();
     console.log("Scheduling initial notification check for challenge:", challengeId);
     


### PR DESCRIPTION
**PR**
- Disables the legacy time-based notification system (9:00 AM / 20:00 modals)
- Prevents outdated modals from appearing and confusing users

**Implementation**
- Legacy logic in `useNotificationSystem.ts` is wrapped in a feature flag
- `shouldShowParticipationBox` and `shouldShowCompletionBox` are blocked when flag is off
- Legacy modal triggers are safely disabled without breaking app initialization

**Testing**

1. Clear localStorage
2. Date.prototype.getHours = () => 20; or 9
3. Reload the page